### PR TITLE
Logging: fixed output format / consistency, fixes #81

### DIFF
--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -224,6 +224,8 @@ volatile unsigned long isr_count_timestamp_2send= micros();
          char          sw[4]                  = {0,0,0,0};
          char          *Serial_Logging_Header = "%10s %15s %10s %9s %9s %8s %9s %9s %9s\n";
          char          *Serial_Logging_Body   = "%10d %15d %10f %9f %9d %8d %9d %9f %9f\n";
+         char          *Serial_One_Minute_Log_Header = "%4s %10s %29s\n";
+         char          *Serial_One_Minute_Log_Body   = "%4d %10d %29d\n";
 
 int Serial_Print_Mode = SERIAL_DEBUG;
 
@@ -395,8 +397,10 @@ void setup()
     Serial.print  ("Simple Multi-Geiger, Version ");
     Serial.println(revString);
     Serial.println("----------------------------------------------------------------------------------------------------------------------------------------------------");
-    Serial.println("Time\tCount_Rate\tCounts");
-    Serial.println("[sec]\t[cpm]\t[Counts per last measurement]");
+    Serial.printf(Serial_One_Minute_Log_Header,
+                  "Time", "Count_Rate", "Counts");
+    Serial.printf(Serial_One_Minute_Log_Header,
+                  "[s]",  "[cpm]",      "[Counts per last measurement]");
     Serial.println("----------------------------------------------------------------------------------------------------------------------------------------------------");
     interrupts();
   }
@@ -539,11 +543,10 @@ void loop()
         if( ( ( ( (lastMinuteLogCounts*60000) % (millis()-lastMinuteLog) ) * 2 ) / (millis()-lastMinuteLog) ) >= 1 ) {
             lastMinuteLogCountRate++;                              // Rounding
         }
-        Serial.print((millis()/1000), DEC);
-        Serial.print("\t");
-        Serial.print(lastMinuteLogCountRate, DEC);    // = *60 /1000 +0.5: to reduce rounding errors
-        Serial.print("\t");
-        Serial.println(lastMinuteLogCounts, DEC);
+        Serial.printf(Serial_One_Minute_Log_Body,
+                      (millis()/1000),
+                      lastMinuteLogCountRate, // = *60 /1000 +0.5: to reduce rounding errors
+                      lastMinuteLogCounts);
         lastMinuteLogCounts = 0;
         lastMinuteLog       = millis();
         interrupts();

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -222,7 +222,8 @@ volatile unsigned long isr_count_timestamp_2send= micros();
          float         bme_pressure           = 0.0;
          float         GMC_factor_uSvph       = 0.0;
          char          sw[4]                  = {0,0,0,0};
-
+         char          *Serial_Logging_Header = "%10s %15s %10s %9s %9s %8s %9s %9s %9s\n";
+         char          *Serial_Logging_Body   = "%10d %15d %10f %9f %9d %8d %9d %9f %9f\n";
 
 int Serial_Print_Mode = SERIAL_DEBUG;
 
@@ -381,8 +382,10 @@ void setup()
     Serial.print  ("Simple Multi-Geiger, Version ");
     Serial.println(revString);
     Serial.println("----------------------------------------------------------------------------------------------------------------------------------------------------");
-    Serial.println("GMC_counts\tTime_difference\tCount_Rate\tDose_Rate\tHV Pulses  \tAccu_GMC  \tAccu_Time \tAccu_Rate         \tAccu_Dose");
-    Serial.println("[Counts]  \t[ms]           \t[cps]     \t[uSv/h]  \t[-]        \t[Counts]  \t[ms]      \t[cps]             \t[uSv/h]");
+    Serial.printf(Serial_Logging_Header,
+                  "GMC_counts", "Time_difference", "Count_Rate", "Dose_Rate", "HV Pulses", "Accu_GMC", "Accu_Time", "Accu_Rate", "Accu_Dose");
+    Serial.printf(Serial_Logging_Header,
+                  "[Counts]",   "[ms]",            "[cps]",      "[uSv/h]",   "[-]",       "[Counts]", "[ms]",      "[cps]",     "[uSv/h]");
     Serial.println("----------------------------------------------------------------------------------------------------------------------------------------------------");
     interrupts();
   }
@@ -524,26 +527,9 @@ void loop()
 
     if (Serial_Print_Mode == Serial_Logging) {                       // Report all
 //      noInterrupts();
-      Serial.print(GMC_counts, DEC);
-      Serial.print("\t");
-      Serial.print(count_timestamp, DEC);
-      Serial.print("\t");
-      Serial.print(time_difference, DEC);
-      Serial.print("\t");
-      Serial.print(Count_Rate, 2);
-      Serial.print("\t");
-      Serial.print(Dose_Rate, 2);
-      Serial.print("\t");
-      Serial.print(HV_pulse_count, DEC);
-      Serial.print("\t");
-      Serial.print(accumulated_GMC_counts, DEC);
-      Serial.print("\t");
-      Serial.print(accumulated_time, DEC);
-      Serial.print("\t");
-      Serial.print(accumulated_Count_Rate, DEC);
-      Serial.print("\t");
-      Serial.print(accumulated_Dose_Rate, DEC);
-      Serial.println();
+      Serial.printf(Serial_Logging_Body,
+                    GMC_counts, time_difference, Count_Rate, Dose_Rate, HV_pulse_count,
+                    accumulated_GMC_counts, accumulated_time, accumulated_Count_Rate, accumulated_Dose_Rate);
 //      interrupts();
     }
     if (Serial_Print_Mode == Serial_One_Minute_Log) {              // 1 Minute Log active?


### PR DESCRIPTION
output generated by first changeset:

```
GMC_counts Time_difference Count_Rate Dose_Rate HV Pulses Accu_GMC Accu_Time Accu_Rate Accu_Dose
  [Counts]            [ms]      [cps]   [uSv/h]       [-] [Counts]      [ms]     [cps]   [uSv/h]
-------------------------------------------------------------------------------------------------------------------------------------------
        90            9995   9.004502  0.000000         1       90      9995  9.004502  0.000000
       100            9440  10.593221  0.000000         1      190     19435  9.776177  0.000000
        99            9736  10.168447  0.000000         1      289     29171  9.907100  0.000000
        89            9662   9.211344  0.000000         1      378     38833  9.733989  0.000000
       100           10223   9.781864  0.000000         1      478     49056  9.743966  0.000000
        88            9975   8.822055  0.000000         1      566     59031  9.588182  0.000000
       100            9236  10.827198  0.000000         1      666     68267  9.755812  0.000000
        93            9984   9.314904  0.000000         1      759     78251  9.699556  0.000000
        90            9917   9.075325  0.000000         1      849     88168  9.629344  0.000000
       100            9263  10.795639  0.000000         1      949     97431  9.740227  0.000000
```