### PR TITLE
LED/speaker tick: fix conditions for alternative delay

### DIFF
--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -465,10 +465,10 @@ void loop()
         digitalWrite (PIN_SPEAKER_OUTPUT_N, LOW);
         delayMicroseconds(500);
       }
-    }
-
-    if(ledTick & !speakerTick) {
-      delay(4);
+    } else {
+      if(ledTick && sw[LED_ON]) {
+        delay(4);
+      }
     }
     if(ledTick && sw[LED_ON]) {
       digitalWrite(LED_BUILTIN, LOW);     // switch off LED


### PR DESCRIPTION
if we want the speaker tick, the tick generation does a delay of 4ms total.
else we need to do an alternative delay of 4ms (so that the LED is on
for 4ms) - but ONLY if the LED is enabled.

this fixes 2 inconsistent conditions for speaker and LED.