### PR TITLE
add TUBE_UNKNOWN 0 to have a specific value for experimenting

### DIFF
--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -48,6 +48,7 @@
 #define   Serial_Statistics_Log  4  // Logs time [us] between two events
 //
 // At sensor.community predefined counter tubes:
+#define TUBE_UNKNOWN 0
 #define SBM20 1
 #define SBM19 2
 #define Si22G 3

--- a/multigeiger/userdefines-example.h
+++ b/multigeiger/userdefines-example.h
@@ -14,6 +14,7 @@
 #endif
 
 // ** select (uncomment) exactly one Geiger-Mueller counter tube:
+// #define TUBE_TYPE TUBE_UNKNOWN  // this can be used for experimenting with other GM tubes and has a 0 CPM to uSv/h conversion factor.
 // #define TUBE_TYPE SBM20
 // #define TUBE_TYPE SBM19
 #define TUBE_TYPE Si22G


### PR DESCRIPTION
if one experiments with a not-yet-supported tube, one wants to
select the entry at index 0 in the tubes array (which is "Radiation
unknown" with a CPM to uSv/h conversion factor of 0.0).

Not sure whether sensor.info and other sites can deal yet with that
sensor type (if values are accidentally submitted), but I guess they
should ignore type 0 tube measurements.

Of course one should usually not submit measurements while
experimenting anyway.