### PR TITLE
Send data or alerts to Telegram Messenger chat

### DIFF
--- a/multigeiger/display.cpp
+++ b/multigeiger/display.cpp
@@ -87,8 +87,9 @@ static const char *status_chars[STATUS_MAX] = {
   ".t3T?",  // ST_TTN_OFF, ST_TTN_IDLE, ST_TTN_ERROR, ST_TTN_SENDING, ST_TTN_INIT
   // group BlueTooth
   ".B4b?",  // ST_BLE_OFF, ST_BLE_CONNECTED, ST_BLE_ERROR, ST_BLE_CONNECTABLE, ST_BLE_INIT
+  // group Telegram
+  ".g5G?",      // ST_TELEGRAM_OFF, ST_TELEGRAM_IDLE, ST_TELEGRAM_ERROR, ST_TELEGRAM_SENDING, ST_TELEGRAM_INIT
   // group other
-  ".",      // ST_NODISPLAY
   ".",      // ST_NODISPLAY
   ".H7",    // ST_NODISPLAY, ST_HV_OK, ST_HV_ERROR
 };

--- a/multigeiger/display.h
+++ b/multigeiger/display.h
@@ -51,7 +51,12 @@ void display_statusline(String txt);
 #define ST_BLE_CONNECTABLE 3
 #define ST_BLE_INIT 4
 
-// status index 5 is still free
+#define STATUS_TELEGRAM 5
+#define ST_TELEGRAM_OFF 0
+#define ST_TELEGRAM_IDLE 1
+#define ST_TELEGRAM_ERROR 2
+#define ST_TELEGRAM_SENDING 3
+#define ST_TELEGRAM_INIT 4
 
 // status index 6 is still free
 

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -149,18 +149,12 @@ void publish(unsigned long current_ms, unsigned long current_counts, unsigned lo
 
     // Sound local alarm?
     if ((soundLocalAlarm || sendLocalAlarmToMessenger) && GMC_factor_uSvph > 0) {
-      if (accumulated_Dose_Rate > localAlarmThreshold) {
-        log(WARNING, "Local alarm: Accumulated dose of %.3f µSv/h above threshold at %.3f µSv/h", accumulated_Dose_Rate, localAlarmThreshold);
-        if (soundLocalAlarm) {
-          alarm();
+      if ((accumulated_Dose_Rate > localAlarmThreshold) || (Dose_Rate > (accumulated_Dose_Rate * localAlarmFactor))) {
+        if (accumulated_Dose_Rate > localAlarmThreshold) {
+          log(WARNING, "Local alarm: Accumulated dose of %.3f µSv/h above threshold at %.3f µSv/h", accumulated_Dose_Rate, localAlarmThreshold);
+        } else {
+          log(WARNING, "Local alarm: Current dose of %.3f > %d x accumulated dose of %.3f µSv/h", Dose_Rate, localAlarmFactor, accumulated_Dose_Rate);
         }
-        if (sendLocalAlarmToMessenger) {
-          transmit_userinfo(tubes[TUBE_TYPE].type, tubes[TUBE_TYPE].nbr, tubes[TUBE_TYPE].cps_to_uSvph,
-                            (unsigned int)(Count_Rate * 60), (unsigned int)(accumulated_Count_Rate * 60), accumulated_Dose_Rate,
-                            have_thp, temperature, humidity, pressure, wifi_status, true);
-        }
-      } else if (Dose_Rate > (accumulated_Dose_Rate * localAlarmFactor)) {
-        log(WARNING, "Local alarm: Current dose of %.3f > %d x accumulated dose of %.3f µSv/h", Dose_Rate, localAlarmFactor, accumulated_Dose_Rate);
         if (soundLocalAlarm) {
           alarm();
         }

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -37,7 +37,7 @@
 
 // DIP switches
 static Switches switches;
-
+float accumulated_Count_Rate = 0.0, accumulated_Dose_Rate = 0.0;
 
 void setup() {
   bool isLoraBoard = init_hwtest();
@@ -107,14 +107,13 @@ int update_ble_status(void) {  // currently no error detection
 }
 
 void publish(unsigned long current_ms, unsigned long current_counts, unsigned long gm_count_timestamp, unsigned long current_hv_pulses,
-             float temperature, float humidity, float pressure) {
+             bool have_thp, float temperature, float humidity, float pressure, int wifi_status) {
   static unsigned long last_timestamp = millis();
   static unsigned long last_counts = 0;
   static unsigned long last_hv_pulses = 0;
   static unsigned long last_count_timestamp = 0;
   static unsigned int accumulated_GMC_counts = 0;
   static unsigned long accumulated_time = 0;
-  static float accumulated_Count_Rate = 0.0, accumulated_Dose_Rate = 0.0;
 
   if (((current_counts - last_counts) >= MINCOUNTS) || ((current_ms - last_timestamp) >= DISPLAYREFRESH)) {
     if ((gm_count_timestamp == 0) && (last_count_timestamp == 0)) {
@@ -149,13 +148,27 @@ void publish(unsigned long current_ms, unsigned long current_counts, unsigned lo
                 (showDisplay && switches.display_on));
 
     // Sound local alarm?
-    if (soundLocalAlarm && GMC_factor_uSvph > 0) {
+    if ((soundLocalAlarm || telegramSendLocalAlarm) && GMC_factor_uSvph > 0) {
       if (accumulated_Dose_Rate > localAlarmThreshold) {
         log(WARNING, "Local alarm: Accumulated dose of %.3f µSv/h above threshold at %.3f µSv/h", accumulated_Dose_Rate, localAlarmThreshold);
-        alarm();
+        if (soundLocalAlarm) {
+          alarm();
+        }
+        if (telegramSendLocalAlarm) {
+          transmit_userinfo(tubes[TUBE_TYPE].type, tubes[TUBE_TYPE].nbr, tubes[TUBE_TYPE].cps_to_uSvph,
+                            (unsigned int)(Count_Rate * 60), (unsigned int)(accumulated_Count_Rate * 60), accumulated_Dose_Rate,
+                            have_thp, temperature, humidity, pressure, wifi_status, true);
+        }
       } else if (Dose_Rate > (accumulated_Dose_Rate * localAlarmFactor)) {
         log(WARNING, "Local alarm: Current dose of %.3f > %d x accumulated dose of %.3f µSv/h", Dose_Rate, localAlarmFactor, accumulated_Dose_Rate);
-        alarm();
+        if (soundLocalAlarm) {
+          alarm();
+        }
+        if (telegramSendLocalAlarm) {
+          transmit_userinfo(tubes[TUBE_TYPE].type, tubes[TUBE_TYPE].nbr, tubes[TUBE_TYPE].cps_to_uSvph,
+                            (unsigned int)(Count_Rate * 60), (unsigned int)(accumulated_Count_Rate * 60), accumulated_Dose_Rate,
+                            have_thp, temperature, humidity, pressure, wifi_status, true);
+        }
       }
     }
 
@@ -236,8 +249,12 @@ void transmit(unsigned long current_ms, unsigned long current_counts, unsigned l
 
     log(DEBUG, "Measured GM: cpm= %d HV=%d", current_cpm, hv_pulses);
 
-    transmit_data(tubes[TUBE_TYPE].type, tubes[TUBE_TYPE].nbr, dt, hv_pulses, counts, current_cpm,
+    transmit_data(tubes[TUBE_TYPE].type, tubes[TUBE_TYPE].nbr,
+                  dt, hv_pulses, counts, current_cpm,
                   have_thp, temperature, humidity, pressure, wifi_status);
+    transmit_userinfo(tubes[TUBE_TYPE].type, tubes[TUBE_TYPE].nbr, tubes[TUBE_TYPE].cps_to_uSvph,
+                  current_cpm, accumulated_Count_Rate, accumulated_Dose_Rate,
+                  have_thp, temperature, humidity, pressure, wifi_status, false);
   }
 }
 
@@ -283,7 +300,7 @@ void loop() {
   // do any other periodic updates for uplinks
   poll_transmission();
 
-  publish(current_ms, gm_counts, gm_count_timestamp, hv_pulses, temperature, humidity, pressure);
+  publish(current_ms, gm_counts, gm_count_timestamp, hv_pulses, have_thp, temperature, humidity, pressure, wifi_status);
 
   if (Serial_Print_Mode == Serial_One_Minute_Log)
     one_minute_log(current_ms, gm_counts);

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -148,13 +148,13 @@ void publish(unsigned long current_ms, unsigned long current_counts, unsigned lo
                 (showDisplay && switches.display_on));
 
     // Sound local alarm?
-    if ((soundLocalAlarm || telegramSendLocalAlarm) && GMC_factor_uSvph > 0) {
+    if ((soundLocalAlarm || sendLocalAlarmToMessenger) && GMC_factor_uSvph > 0) {
       if (accumulated_Dose_Rate > localAlarmThreshold) {
         log(WARNING, "Local alarm: Accumulated dose of %.3f µSv/h above threshold at %.3f µSv/h", accumulated_Dose_Rate, localAlarmThreshold);
         if (soundLocalAlarm) {
           alarm();
         }
-        if (telegramSendLocalAlarm) {
+        if (sendLocalAlarmToMessenger) {
           transmit_userinfo(tubes[TUBE_TYPE].type, tubes[TUBE_TYPE].nbr, tubes[TUBE_TYPE].cps_to_uSvph,
                             (unsigned int)(Count_Rate * 60), (unsigned int)(accumulated_Count_Rate * 60), accumulated_Dose_Rate,
                             have_thp, temperature, humidity, pressure, wifi_status, true);
@@ -164,7 +164,7 @@ void publish(unsigned long current_ms, unsigned long current_counts, unsigned lo
         if (soundLocalAlarm) {
           alarm();
         }
-        if (telegramSendLocalAlarm) {
+        if (sendLocalAlarmToMessenger) {
           transmit_userinfo(tubes[TUBE_TYPE].type, tubes[TUBE_TYPE].nbr, tubes[TUBE_TYPE].cps_to_uSvph,
                             (unsigned int)(Count_Rate * 60), (unsigned int)(accumulated_Count_Rate * 60), accumulated_Dose_Rate,
                             have_thp, temperature, humidity, pressure, wifi_status, true);

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -253,8 +253,8 @@ void transmit(unsigned long current_ms, unsigned long current_counts, unsigned l
                   dt, hv_pulses, counts, current_cpm,
                   have_thp, temperature, humidity, pressure, wifi_status);
     transmit_userinfo(tubes[TUBE_TYPE].type, tubes[TUBE_TYPE].nbr, tubes[TUBE_TYPE].cps_to_uSvph,
-                  current_cpm, accumulated_Count_Rate, accumulated_Dose_Rate,
-                  have_thp, temperature, humidity, pressure, wifi_status, false);
+                      current_cpm, accumulated_Count_Rate, accumulated_Dose_Rate,
+                      have_thp, temperature, humidity, pressure, wifi_status, false);
   }
 }
 

--- a/multigeiger/transmission.cpp
+++ b/multigeiger/transmission.cpp
@@ -71,14 +71,14 @@ void setup_transmission(const char *version, char *ssid, bool loraHardware) {
   c_customsrv.wc->setCACert(ca_certs);
   c_customsrv.hc = new HTTPClient;
 
-  if ((sizeof(telegramBotToken)<40) && (sizeof(telegramChatId)<7))
+  if ((sizeof(telegramBotToken) < 40) && (sizeof(telegramChatId) < 7))
     sendToTelegramEvery = -1;
 
   c_telegram.wc = new WiFiClientSecure;
   c_telegram.wc->setCACert(TELEGRAM_CERTIFICATE_ROOT);
   c_telegram.hc = new HTTPClient;
 
-  if (sendToTelegramEvery>=0) {
+  if (sendToTelegramEvery >= 0) {
     log(DEBUG, "Starting Telegram Bot...");
     telegram_bot = new UniversalTelegramBot(telegramBotToken, *(c_telegram.wc));
   }

--- a/multigeiger/transmission.cpp
+++ b/multigeiger/transmission.cpp
@@ -71,7 +71,7 @@ void setup_transmission(const char *version, char *ssid, bool loraHardware) {
   c_customsrv.wc->setCACert(ca_certs);
   c_customsrv.hc = new HTTPClient;
 
-  if ((sizeof(telegramBotToken) < 40) || (sizeof(telegramChatId) < 7))
+  if ((strlen(telegramBotToken) < 40) || (strlen(telegramChatId) < 7))
     sendDataToMessengerEvery = -1;
 
   c_telegram.wc = new WiFiClientSecure;
@@ -321,8 +321,13 @@ void transmit_userinfo(String tube_type, int tube_nbr, float tube_factor, unsign
     return;
 
   // if we don't have a valid Messenger config, do not send to Messenger
-  if ((sizeof(telegramBotToken) < 40) || (sizeof(telegramChatId) < 7))
+  if (sendDataToMessengerEvery < 0)
+    return;
+  // in case the config has been changed in the meantime
+  if ((strlen(telegramBotToken) < 40) || (strlen(telegramChatId) < 7)) {
     sendDataToMessengerEvery = -1;
+    return;
+  }
 
   static unsigned int transmitCounter = 0;
   transmitCounter++;

--- a/multigeiger/transmission.h
+++ b/multigeiger/transmission.h
@@ -17,6 +17,8 @@
 void setup_transmission(const char *version, char *ssid, bool lora);
 void transmit_data(String tube_type, int tube_nbr, unsigned int dt, unsigned int hv_pulses, unsigned int gm_counts, unsigned int cpm,
                    int have_thp, float temperature, float humidity, float pressure, int wifi_status);
+void transmit_userinfo(String tube_type, int tube_nbr, float tube_factor, unsigned int cpm, unsigned int accu_cpm, float accu_rate,
+                       int have_thp, float temperature, float humidity, float pressure, int wifi_status, bool alarm_status);
 
 // The Arduino LMIC wants to be polled from loop(). This takes care of that on LoRa boards.
 void poll_transmission(void);

--- a/multigeiger/userdefines-example.h
+++ b/multigeiger/userdefines-example.h
@@ -83,26 +83,24 @@
 // ! Requires a valid tube type to be set in order to calculate dose rate.
 #define LOCAL_ALARM_FACTOR 3  // current / accumulated dose rate
 
-// Send MultiGeiger info and alerts to Telegram Messenger chat
+// Send MultiGeiger info and alerts to Messaging services. Currently supported:
+// - Telegram Messenger
 // REQUIRES WIFI CONNECTION!
-// Update via Telegram Messenger every N sensor.community messages (default 150 s / 2.5 min)
+// Update via Messenger every N sensor.community messages (default 150 s / 2.5 min)
 // Set to 0 to disable normal data transfer
-// 24 = 1/hour, 576 = 1/day, 4032 = 1/week
-#define TELEGRAM_TICKER_EVERY 0
+// 24 = 1/hour, 576 = 1/day, 4032 = 1/week, max: 27719 (~48 days)
+#define SEND_DATA_TO_MESSENGER_EVERY 0
 
+// Send local alerts via supported Messenger services
+// See above for more info on local alerts
+#define SEND_LOCAL_ALARM_TO_MESSENGER true
+
+///// TELEGRAM MESSENGER
 // To communicate with the Telegram Messenger on your phone you need to create a bot
 // Starting point: https://core.telegram.org/bots
-// You will get a Bot token, please insert this here within ""
+// You will get a Bot token, please provide this via Web Config
 // Form: "XXXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-// Default: Empty string ""
-#define TELEGRAM_BOT_TOKEN ""  // "XXXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-
 // Important: Start your bot channel with the command "/start" and receive the Chat ID
-// In order to get MultiGeiger messages to your specific chat, please provide this Chat ID here, again within ""
-// Form: "1234567890"
-// Default: Empty string ""
-#define TELEGRAM_CHAT_ID ""  // "1234567890"
+// In order to get MultiGeiger messages to your specific chat, please provide this Chat ID via Web Config
+// Form: "123456789"
 
-// Send local alerts via Telegram Messenger
-// See above for more info on local alerts
-#define TELEGRAM_ALERT true

--- a/multigeiger/userdefines-example.h
+++ b/multigeiger/userdefines-example.h
@@ -86,21 +86,21 @@
 // Send MultiGeiger info and alerts to Messaging services. Currently supported:
 // - Telegram Messenger
 // REQUIRES WIFI CONNECTION!
-// Update via Messenger every N sensor.community messages (default 150 s / 2.5 min)
-// Set to 0 to disable normal data transfer
+// Update via Messenger every N sensor.community messages (default 150 s / 2.5 min).
+// Set to 0 to disable normal data transfer.
 // 24 = 1/hour, 576 = 1/day, 4032 = 1/week, max: 27719 (~48 days)
 #define SEND_DATA_TO_MESSENGER_EVERY 0
 
-// Send local alerts via supported Messenger services
-// See above for more info on local alerts
+// Send local alerts via supported Messenger services.
+// See above for more info on local alerts.
 #define SEND_LOCAL_ALARM_TO_MESSENGER true
 
 ///// TELEGRAM MESSENGER
-// To communicate with the Telegram Messenger on your phone you need to create a bot
+// To communicate with the Telegram Messenger on your phone you need to create a bot.
 // Starting point: https://core.telegram.org/bots
-// You will get a Bot token, please provide this via Web Config
+// You will get a Bot token, please provide this via Web Config.
 // Form: "XXXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-// Important: Start your bot channel with the command "/start" and receive the Chat ID
-// In order to get MultiGeiger messages to your specific chat, please provide this Chat ID via Web Config
+// Important: Start your bot channel with the command "/start" and receive the Chat ID.
+// In order to get MultiGeiger messages to your specific chat, please provide this Chat ID via Web Config.
 // Form: "123456789"
 

--- a/multigeiger/userdefines-example.h
+++ b/multigeiger/userdefines-example.h
@@ -82,3 +82,27 @@
 // If current dose rate rises to (default) 3 times the accumulated dose rate, i.e. 0.3 µSv/h, trigger the local alarm.
 // ! Requires a valid tube type to be set in order to calculate dose rate.
 #define LOCAL_ALARM_FACTOR 3  // current / accumulated dose rate
+
+// Send MultiGeiger info and alerts to Telegram Messenger chat
+// REQUIRES WIFI CONNECTION!
+// Update via Telegram Messenger every N sensor.community messages (default 150 s / 2.5 min)
+// Set to 0 to disable normal data transfer
+// 24 = 1/hour, 576 = 1/day, 4032 = 1/week
+#define TELEGRAM_TICKER_EVERY 0
+
+// To communicate with the Telegram Messenger on your phone you need to create a bot
+// Starting point: https://core.telegram.org/bots
+// You will get a Bot token, please insert this here within ""
+// Form: "XXXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+// Default: Empty string ""
+#define TELEGRAM_BOT_TOKEN ""  // "XXXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+// Important: Start your bot channel with the command "/start" and receive the Chat ID
+// In order to get MultiGeiger messages to your specific chat, please provide this Chat ID here, again within ""
+// Form: "1234567890"
+// Default: Empty string ""
+#define TELEGRAM_CHAT_ID ""  // "1234567890"
+
+// Send local alerts via Telegram Messenger
+// See above for more info on local alerts
+#define TELEGRAM_ALERT true

--- a/multigeiger/webconf.cpp
+++ b/multigeiger/webconf.cpp
@@ -40,10 +40,12 @@ static bool isLoraBoard;
 float localAlarmThreshold = LOCAL_ALARM_THRESHOLD;
 int localAlarmFactor = (int)LOCAL_ALARM_FACTOR;
 
-int sendToTelegramEvery = (int)TELEGRAM_TICKER_EVERY;
-char telegramBotToken[50] = TELEGRAM_BOT_TOKEN;  // "XXXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-char telegramChatId[12] = TELEGRAM_CHAT_ID;  // "1234567890"
-bool telegramSendLocalAlarm = TELEGRAM_ALERT;
+int sendDataToMessengerEvery = (int)SEND_DATA_TO_MESSENGER_EVERY;
+bool sendLocalAlarmToMessenger = SEND_LOCAL_ALARM_TO_MESSENGER;
+char telegramBotToken[50] = "";  // "XXXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+char telegramChatId[12] = "";  // "1234567890"
+
+char sendLocalAlarmToMessenger_c[CHECKBOX_LEN];
 
 iotwebconf::ParameterGroup grpMisc = iotwebconf::ParameterGroup("misc", "Misc. Settings");
 iotwebconf::CheckboxParameter startSoundParam = iotwebconf::CheckboxParameter("Start sound", "startSound", playSound_c, CHECKBOX_LEN, playSound);
@@ -62,7 +64,7 @@ iotwebconf::TextParameter deveuiParam = iotwebconf::TextParameter("DEVEUI", "dev
 iotwebconf::TextParameter appeuiParam = iotwebconf::TextParameter("APPEUI", "appeui", appeui, 17);
 iotwebconf::TextParameter appkeyParam = iotwebconf::TextParameter("APPKEY", "appkey", appkey, 33);
 
-iotwebconf::ParameterGroup grpAlarm = iotwebconf::ParameterGroup("alarm", "Local Alarm Setting");
+iotwebconf::ParameterGroup grpAlarm = iotwebconf::ParameterGroup("alarm", "Local Alarm Settings");
 iotwebconf::CheckboxParameter soundLocalAlarmParam = iotwebconf::CheckboxParameter("Enable local alarm sound", "soundLocalAlarm", soundLocalAlarm_c, CHECKBOX_LEN, soundLocalAlarm);
 iotwebconf::FloatTParameter localAlarmThresholdParam =
   iotwebconf::Builder<iotwebconf::FloatTParameter>("localAlarmThreshold").
@@ -75,6 +77,19 @@ iotwebconf::IntTParameter<int16_t> localAlarmFactorParam =
   defaultValue(localAlarmFactor).
   min(2).max(100).
   step(1).placeholder("2..100").build();
+
+iotwebconf::ParameterGroup grpMessenger = iotwebconf::ParameterGroup("messenger", "Messenger Settings");
+iotwebconf::CheckboxParameter sendLocalAlarmToMessengerParam = iotwebconf::CheckboxParameter("Send local alarm via Messenger", "sendLocalAlarmToMessenger", sendLocalAlarmToMessenger_c, CHECKBOX_LEN, sendLocalAlarmToMessenger);
+iotwebconf::IntTParameter<int16_t> sendDataToMessengerEveryParam =
+  iotwebconf::Builder<iotwebconf::IntTParameter<int16_t>>("sendDataToMessengerEvery").
+  label("Send data via Messenger every N x 2.5min\n(0=never,24=1/h,576=1/d,4032=1/week,max:27719)").
+  defaultValue(sendDataToMessengerEvery).
+  min(0).max(27719).
+  step(1).placeholder("0..27719").build();
+// iotwebconf::TextParameter telegramBotTokenParam = iotwebconf::TextParameter("Telegram Bot Token", "telegramBotToken", telegramBotToken, 50);
+iotwebconf::PasswordParameter telegramBotTokenParam = iotwebconf::PasswordParameter("Telegram Bot Token", "telegramBotToken", telegramBotToken, 50);
+iotwebconf::PasswordParameter telegramChatIdParam = iotwebconf::PasswordParameter("Telegram Chat ID", "telegramChatId", telegramChatId, 12);
+
 
 // This only needs to be changed if the layout of the configuration is changed.
 // Appending new variables does not require a new version number here.
@@ -167,6 +182,8 @@ void loadConfigVariables(void) {
   soundLocalAlarm = soundLocalAlarmParam.isChecked();
   localAlarmThreshold = localAlarmThresholdParam.value();
   localAlarmFactor = localAlarmFactorParam.value();
+  sendDataToMessengerEvery = sendDataToMessengerEveryParam.value();
+  sendLocalAlarmToMessenger = sendLocalAlarmToMessengerParam.isChecked();
 }
 
 void configSaved(void) {
@@ -210,10 +227,19 @@ void setup_webconf(bool loraHardware) {
   grpAlarm.addItem(&localAlarmThresholdParam);
   grpAlarm.addItem(&localAlarmFactorParam);
   iotWebConf.addParameterGroup(&grpAlarm);
+  grpMessenger.addItem(&sendDataToMessengerEveryParam);
+  grpMessenger.addItem(&sendLocalAlarmToMessengerParam);
+  grpMessenger.addItem(&telegramBotTokenParam);
+  grpMessenger.addItem(&telegramChatIdParam);
+  iotWebConf.addParameterGroup(&grpMessenger);
 
   // if we don't have LoRa hardware, do not send to LoRa
   if (!isLoraBoard)
     sendToLora = false;
+
+  // if we don't have a valid Messenger config, do not send to Messenger
+  if ((sizeof(telegramBotToken) < 40) || (sizeof(telegramChatId) < 7))
+    sendDataToMessengerEvery = -1;
 
   iotWebConf.init();
 

--- a/multigeiger/webconf.cpp
+++ b/multigeiger/webconf.cpp
@@ -86,8 +86,7 @@ iotwebconf::IntTParameter<int16_t> sendDataToMessengerEveryParam =
   defaultValue(sendDataToMessengerEvery).
   min(0).max(27719).
   step(1).placeholder("0..27719").build();
-// iotwebconf::TextParameter telegramBotTokenParam = iotwebconf::TextParameter("Telegram Bot Token", "telegramBotToken", telegramBotToken, 50);
-iotwebconf::PasswordParameter telegramBotTokenParam = iotwebconf::PasswordParameter("Telegram Bot Token", "telegramBotToken", telegramBotToken, 50);
+iotwebconf::PasswordParameter telegramBotTokenParam = iotwebconf::PasswordParameter("Telegram Bot Token (Reboot required!)", "telegramBotToken", telegramBotToken, 50);
 iotwebconf::PasswordParameter telegramChatIdParam = iotwebconf::PasswordParameter("Telegram Chat ID", "telegramChatId", telegramChatId, 12);
 
 
@@ -236,10 +235,6 @@ void setup_webconf(bool loraHardware) {
   // if we don't have LoRa hardware, do not send to LoRa
   if (!isLoraBoard)
     sendToLora = false;
-
-  // if we don't have a valid Messenger config, do not send to Messenger
-  if ((sizeof(telegramBotToken) < 40) || (sizeof(telegramChatId) < 7))
-    sendDataToMessengerEvery = -1;
 
   iotWebConf.init();
 

--- a/multigeiger/webconf.cpp
+++ b/multigeiger/webconf.cpp
@@ -40,6 +40,11 @@ static bool isLoraBoard;
 float localAlarmThreshold = LOCAL_ALARM_THRESHOLD;
 int localAlarmFactor = (int)LOCAL_ALARM_FACTOR;
 
+int sendToTelegramEvery = (int)TELEGRAM_TICKER_EVERY;
+char telegramBotToken[50] = TELEGRAM_BOT_TOKEN;  // "XXXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+char telegramChatId[12] = TELEGRAM_CHAT_ID;  // "1234567890"
+bool telegramSendLocalAlarm = TELEGRAM_ALERT;
+
 iotwebconf::ParameterGroup grpMisc = iotwebconf::ParameterGroup("misc", "Misc. Settings");
 iotwebconf::CheckboxParameter startSoundParam = iotwebconf::CheckboxParameter("Start sound", "startSound", playSound_c, CHECKBOX_LEN, playSound);
 iotwebconf::CheckboxParameter speakerTickParam = iotwebconf::CheckboxParameter("Speaker tick", "speakerTick", speakerTick_c, CHECKBOX_LEN, speakerTick);

--- a/multigeiger/webconf.h
+++ b/multigeiger/webconf.h
@@ -23,10 +23,10 @@ extern char appkey[];
 extern float localAlarmThreshold;
 extern int localAlarmFactor;
 
-extern int sendToTelegramEvery;
+extern int sendDataToMessengerEvery;
 extern char telegramBotToken[50];
 extern char telegramChatId[15];
-extern bool telegramSendLocalAlarm;
+extern bool sendLocalAlarmToMessenger;
 
 extern char ssid[];
 extern IotWebConf iotWebConf;

--- a/multigeiger/webconf.h
+++ b/multigeiger/webconf.h
@@ -23,6 +23,11 @@ extern char appkey[];
 extern float localAlarmThreshold;
 extern int localAlarmFactor;
 
+extern int sendToTelegramEvery;
+extern char telegramBotToken[50];
+extern char telegramChatId[15];
+extern bool telegramSendLocalAlarm;
+
 extern char ssid[];
 extern IotWebConf iotWebConf;
 

--- a/platformio-example.ini
+++ b/platformio-example.ini
@@ -31,3 +31,4 @@ lib_deps=
   IotWebConf@^3.1.0
   MCCI LoRaWAN LMIC library
   h2zero/NimBLE-Arduino
+  witnessmenow/UniversalTelegramBot@^1.3.0


### PR DESCRIPTION
First commit sending regular data and/or alerts to Telegram messenger on phone
- config via userdefines.h
- send data every (N) transmissions, i.e. every N*2.5 min to Telegram channel
- send local alerts also to Telegram channel