### PR TITLE
Refactor GMC data processing

### DIFF
--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -121,7 +121,7 @@ void local_alarmsequence(void) {
 }
 
 void process_GMC(unsigned long current_ms, unsigned long current_counts, unsigned long gm_count_timestamp, unsigned long current_hv_pulses,
-              bool have_thp, float temperature, float humidity, float pressure, int wifi_status) {
+                 bool have_thp, float temperature, float humidity, float pressure, int wifi_status) {
   struct GM_State {
     unsigned long timestamp;
     unsigned long counts;
@@ -144,7 +144,7 @@ void process_GMC(unsigned long current_ms, unsigned long current_counts, unsigne
   };
 
   // millis(), counts or hv_pulses overflow?
-  for (int i = 0; i<savedstates_count; i++) {
+  for (int i = 0; i < savedstates_count; i++) {
     if (current_ms < saved_state[i].timestamp) saved_state[i].timestamp = current_ms;
     if (current_counts < saved_state[i].counts) saved_state[i].counts = current_counts;
     if (gm_count_timestamp < saved_state[i].last_count_timestamp) saved_state[i].last_count_timestamp = gm_count_timestamp;
@@ -157,7 +157,7 @@ void process_GMC(unsigned long current_ms, unsigned long current_counts, unsigne
 
   // Startup
   if ((gm_count_timestamp == 0) && (saved_state[HEARTBEAT].last_count_timestamp == 0)) {
-      // If there were no pulses after AFTERSTART msecs after boot, clear display anyway and show 0 counts.
+    // If there were no pulses after AFTERSTART msecs after boot, clear display anyway and show 0 counts.
     static unsigned long boot_timestamp = millis();
     static unsigned long afterStartTime = AFTERSTART * 1000;
     if (afterStartTime && ((current_ms - boot_timestamp) >= afterStartTime)) {
@@ -226,17 +226,17 @@ void process_GMC(unsigned long current_ms, unsigned long current_counts, unsigne
       dose_rate = count_rate * GMC_factor_uSvph;
 
       switch (st) {
-        case MEASUREMENT:
-          log(DEBUG, "Measured GM: cpm= %d HV=%d", current_cpm, hv_pulses);
-          transmit_data(tubes[TUBE_TYPE].type, tubes[TUBE_TYPE].nbr, dt, hv_pulses, counts, current_cpm,
-                        have_thp, temperature, humidity, pressure, wifi_status);
-          break;
-        case ONE_MINUTE:
-          if (Serial_Print_Mode == Serial_One_Minute_Log)
-            log_data_one_minute((current_ms / 1000), current_cpm, counts);
-          break;
-        default:
-          break;
+      case MEASUREMENT:
+        log(DEBUG, "Measured GM: cpm= %d HV=%d", current_cpm, hv_pulses);
+        transmit_data(tubes[TUBE_TYPE].type, tubes[TUBE_TYPE].nbr, dt, hv_pulses, counts, current_cpm,
+                      have_thp, temperature, humidity, pressure, wifi_status);
+        break;
+      case ONE_MINUTE:
+        if (Serial_Print_Mode == Serial_One_Minute_Log)
+          log_data_one_minute((current_ms / 1000), current_cpm, counts);
+        break;
+      default:
+        break;
       }
       saved_state[st].timestamp = current_ms;
       saved_state[st].counts = current_counts;

--- a/multigeiger/multigeiger.ino
+++ b/multigeiger/multigeiger.ino
@@ -22,14 +22,11 @@
 // Measurement interval (default 2.5min) [sec]
 #define MEASUREMENT_INTERVAL 150
 
-// Max time the greeting display will be on. [msec]
-#define AFTERSTART 5000
+// Max time the greeting display will be on. [sec]
+#define AFTERSTART 5
 
-// In which intervals the OLED display is updated. [msec]
-#define DISPLAYREFRESH 10000
-
-// Minimum amount of GM pulses required to early-update the display.
-#define MINCOUNTS 100
+// Basic heartbeat for serial log, BLE and OLED refresh [sec]
+#define HEARTBEAT_INTERVAL 10
 
 // Target loop duration [ms]
 // slow down the arduino main loop so it spins about once per LOOP_DURATION -
@@ -106,138 +103,146 @@ int update_ble_status(void) {  // currently no error detection
   return st;
 }
 
-void publish(unsigned long current_ms, unsigned long current_counts, unsigned long gm_count_timestamp, unsigned long current_hv_pulses,
-             float temperature, float humidity, float pressure) {
-  static unsigned long last_timestamp = millis();
-  static unsigned long last_counts = 0;
-  static unsigned long last_hv_pulses = 0;
-  static unsigned long last_count_timestamp = 0;
+void read_THP(unsigned long current_ms,
+              bool *have_thp, float *temperature, float *humidity, float *pressure) {
+  static unsigned long last_timestamp = 0;
+  // first call: immediately query thp sensor
+  // subsequent calls: only query every HEARTBEAT_INTERVAL
+  if (!last_timestamp || ((current_ms - last_timestamp) >= (HEARTBEAT_INTERVAL * 1000))) {
+    *have_thp = read_thp_sensor(temperature, humidity, pressure);
+    last_timestamp = current_ms;
+  }
+}
+
+void local_alarmsequence(void) {
+  // call all alarm action options
+  // currently local beep every display refresh
+  alarm();
+}
+
+void process_GMC(unsigned long current_ms, unsigned long current_counts, unsigned long gm_count_timestamp, unsigned long current_hv_pulses,
+              bool have_thp, float temperature, float humidity, float pressure, int wifi_status) {
+  struct GM_State {
+    unsigned long timestamp;
+    unsigned long counts;
+    unsigned long last_count_timestamp;
+    unsigned long hv_pulses;
+  };
+
+  // Events
+  const byte HEARTBEAT = 0;
+  const byte MEASUREMENT = 1;
+  const byte ONE_MINUTE = 2;
+
+  const int savedstates_count = 3;
+
+  static GM_State saved_state[savedstates_count];
+  long event_interval[savedstates_count] = {
+    HEARTBEAT_INTERVAL * 1000,  // Basic heartbeat interval
+    MEASUREMENT_INTERVAL * 1000,  // Send measurements to server interval
+    60 * 1000  // 60 sec
+  };
+
+  // millis(), counts or hv_pulses overflow?
+  for (int i = 0; i<savedstates_count; i++) {
+    if (current_ms < saved_state[i].timestamp) saved_state[i].timestamp = current_ms;
+    if (current_counts < saved_state[i].counts) saved_state[i].counts = current_counts;
+    if (gm_count_timestamp < saved_state[i].last_count_timestamp) saved_state[i].last_count_timestamp = gm_count_timestamp;
+    if (current_hv_pulses < saved_state[i].hv_pulses) saved_state[i].hv_pulses = current_hv_pulses;
+  }
+
   static unsigned int accumulated_GMC_counts = 0;
   static unsigned long accumulated_time = 0;
   static float accumulated_Count_Rate = 0.0, accumulated_Dose_Rate = 0.0;
 
-  if (((current_counts - last_counts) >= MINCOUNTS) || ((current_ms - last_timestamp) >= DISPLAYREFRESH)) {
-    if ((gm_count_timestamp == 0) && (last_count_timestamp == 0)) {
-      // seems like there was no GM pulse yet and everything is still in initial state.
-      // get out of here, we can't do anything useful now.
-      return;
-    }
-    last_timestamp = current_ms;
-    int hv_pulses = current_hv_pulses - last_hv_pulses;
-    last_hv_pulses = current_hv_pulses;
-    int counts = current_counts - last_counts;
-    last_counts = current_counts;
-    int dt = gm_count_timestamp - last_count_timestamp;
-    last_count_timestamp = gm_count_timestamp;
-
-    accumulated_time += dt;
-    accumulated_GMC_counts = current_counts;
-
-    float GMC_factor_uSvph = tubes[TUBE_TYPE].cps_to_uSvph;
-
-    // calculate the current count rate and dose rate
-    float Count_Rate = (dt != 0) ? (float)counts * 1000.0 / (float)dt : 0.0;
-    float Dose_Rate = Count_Rate * GMC_factor_uSvph;
-
-    // calculate the count rate and dose rate over the complete time from start
-    accumulated_Count_Rate = (accumulated_time != 0) ? (float)accumulated_GMC_counts * 1000.0 / (float)accumulated_time : 0.0;
-    accumulated_Dose_Rate = accumulated_Count_Rate * GMC_factor_uSvph;
-
-    // ... and update the data on display, notify via BLE
-    update_bledata((unsigned int)(Count_Rate * 60));
-    display_GMC((unsigned int)(accumulated_time / 1000), (int)(accumulated_Dose_Rate * 1000), (int)(Count_Rate * 60),
-                (showDisplay && switches.display_on));
-
-    // Sound local alarm?
-    if (soundLocalAlarm && GMC_factor_uSvph > 0) {
-      if (accumulated_Dose_Rate > localAlarmThreshold) {
-        log(WARNING, "Local alarm: Accumulated dose of %.3f µSv/h above threshold at %.3f µSv/h", accumulated_Dose_Rate, localAlarmThreshold);
-        alarm();
-      } else if (Dose_Rate > (accumulated_Dose_Rate * localAlarmFactor)) {
-        log(WARNING, "Local alarm: Current dose of %.3f > %d x accumulated dose of %.3f µSv/h", Dose_Rate, localAlarmFactor, accumulated_Dose_Rate);
-        alarm();
-      }
-    }
-
-    if (Serial_Print_Mode == Serial_Logging) {
-      log_data(counts, dt, Count_Rate, Dose_Rate, hv_pulses,
-               accumulated_GMC_counts, accumulated_time, accumulated_Count_Rate, accumulated_Dose_Rate,
-               temperature, humidity, pressure);
-    }
-  } else {
-    // If there were no pulses after AFTERSTART msecs after boot, clear display anyway and show 0 counts.
+  // Startup
+  if ((gm_count_timestamp == 0) && (saved_state[HEARTBEAT].last_count_timestamp == 0)) {
+      // If there were no pulses after AFTERSTART msecs after boot, clear display anyway and show 0 counts.
     static unsigned long boot_timestamp = millis();
-    static unsigned long afterStartTime = AFTERSTART;
+    static unsigned long afterStartTime = AFTERSTART * 1000;
     if (afterStartTime && ((current_ms - boot_timestamp) >= afterStartTime)) {
       afterStartTime = 0;
       update_bledata(0);
       display_GMC(0, 0, 0, (showDisplay && switches.display_on));
     }
+    return;
   }
-}
 
-void one_minute_log(unsigned long current_ms, unsigned long current_counts) {
-  static unsigned int last_counts = 0;
-  static unsigned long last_timestamp = millis();
-  int dt = current_ms - last_timestamp;
-  if (dt >= 60000) {
-    unsigned long counts = current_counts - last_counts;
-    unsigned int count_rate = (counts * 60000) / dt;
-    if (((((counts * 60000) % dt) * 2) / dt) >= 1) {
-      count_rate++;  // Rounding + 0.5
+  // Heartbeat; all other events snap to the next heartbeat interval
+  if ((current_ms - saved_state[HEARTBEAT].timestamp) >= event_interval[HEARTBEAT]) {
+    unsigned long counts = current_counts - saved_state[HEARTBEAT].counts;
+    int dt = gm_count_timestamp - saved_state[HEARTBEAT].last_count_timestamp;
+    unsigned int current_cpm = (dt != 0) ? (int)(counts * 60000 / dt) : 0;
+    int hv_pulses = current_hv_pulses - saved_state[HEARTBEAT].hv_pulses;
+    accumulated_time += dt;
+    accumulated_GMC_counts = current_counts;
+    float GMC_factor_uSvph = tubes[TUBE_TYPE].cps_to_uSvph;
+
+    // calculate the current count rate and dose rate
+    float count_rate = (dt != 0) ? (float)counts * 1000.0 / (float)dt : 0.0;
+    float dose_rate = count_rate * GMC_factor_uSvph;
+
+    // calculate the count rate and dose rate over the complete time from start
+    accumulated_Count_Rate = (accumulated_time != 0) ? (float)accumulated_GMC_counts * 1000.0 / (float)accumulated_time : 0.0;
+    accumulated_Dose_Rate = accumulated_Count_Rate * GMC_factor_uSvph;
+
+    // Serial logging
+    if (Serial_Print_Mode == Serial_Logging) {
+      log_data(counts, dt, count_rate, dose_rate, hv_pulses,
+               accumulated_GMC_counts, accumulated_time, accumulated_Count_Rate, accumulated_Dose_Rate,
+               temperature, humidity, pressure);
     }
-    log_data_one_minute((current_ms / 1000), count_rate, counts);
-    last_timestamp = current_ms;
-    last_counts = current_counts;
-  }
-}
 
-void statistics_log(unsigned long current_counts, unsigned int time_between) {
-  static unsigned long last_counts = 0;
-  if (current_counts != last_counts) {
-    log_data_statistics(time_between);
-    last_counts = current_counts;
-  }
-}
+    // Update data on display and notify via BLE
+    display_GMC((unsigned int)(accumulated_time / 1000), (int)(accumulated_Dose_Rate * 1000), (int)(count_rate * 60),
+                (showDisplay && switches.display_on));
+    update_bledata((unsigned int)(count_rate * 60));
 
-void read_THP(unsigned long current_ms,
-              bool *have_thp, float *temperature, float *humidity, float *pressure) {
-  static unsigned long last_timestamp = 0;
-  // first call: immediately query thp sensor
-  // subsequent calls: only query every MEASUREMENT_INTERVAL
-  if (!last_timestamp || (current_ms - last_timestamp) >= (MEASUREMENT_INTERVAL * 1000)) {
-    last_timestamp = current_ms;
-    *have_thp = read_thp_sensor(temperature, humidity, pressure);
-  }
-}
-
-void transmit(unsigned long current_ms, unsigned long current_counts, unsigned long gm_count_timestamp, unsigned long current_hv_pulses,
-              bool have_thp, float temperature, float humidity, float pressure, int wifi_status) {
-  static unsigned long last_counts = 0;
-  static unsigned long last_hv_pulses = 0;
-  static unsigned long last_timestamp = millis();
-  static unsigned long last_count_timestamp = 0;
-  if ((current_ms - last_timestamp) >= (MEASUREMENT_INTERVAL * 1000)) {
-    if ((gm_count_timestamp == 0) && (last_count_timestamp == 0)) {
-      // seems like there was no GM pulse yet and everything is still in initial state.
-      // get out of here, we can't do anything useful now.
-      return;
+    // Check for local alarm
+    if (soundLocalAlarm && GMC_factor_uSvph > 0) {
+      if (accumulated_Dose_Rate > localAlarmThreshold) {
+        log(WARNING, "Local alarm: Accumulated dose of %.3f µSv/h above threshold at %.3f µSv/h", accumulated_Dose_Rate, localAlarmThreshold);
+        local_alarmsequence();
+      } else if (dose_rate > (accumulated_Dose_Rate * localAlarmFactor)) {
+        log(WARNING, "Local alarm: Current dose of %.3f > %d x accumulated dose of %.3f µSv/h", dose_rate, localAlarmFactor, accumulated_Dose_Rate);
+        local_alarmsequence();
+      }
     }
-    last_timestamp = current_ms;
-    unsigned long counts = current_counts - last_counts;
-    last_counts = current_counts;
-    int dt = gm_count_timestamp - last_count_timestamp;
-    last_count_timestamp = gm_count_timestamp;
-    unsigned int current_cpm;
-    current_cpm = (dt != 0) ? (int)(counts * 60000 / dt) : 0;
+    saved_state[HEARTBEAT].timestamp = current_ms;
+    saved_state[HEARTBEAT].counts = current_counts;
+    saved_state[HEARTBEAT].last_count_timestamp = gm_count_timestamp;
+    saved_state[HEARTBEAT].hv_pulses = current_hv_pulses;
 
-    int hv_pulses = current_hv_pulses - last_hv_pulses;
-    last_hv_pulses = current_hv_pulses;
+    // Handle all the other events
+    for (int st = 1; st < savedstates_count; st++) {
+      if ((current_ms - saved_state[st].timestamp) < event_interval[st])
+        continue;
+      // adapt difference data to event's last saved state
+      counts = current_counts - saved_state[st].counts;
+      dt = gm_count_timestamp - saved_state[st].last_count_timestamp;
+      current_cpm = (dt != 0) ? (int)(counts * 60000 / dt) : 0;
+      hv_pulses = current_hv_pulses - saved_state[st].hv_pulses;
+      count_rate = (dt != 0) ? (float)counts * 1000.0 / (float)dt : 0.0;
+      dose_rate = count_rate * GMC_factor_uSvph;
 
-    log(DEBUG, "Measured GM: cpm= %d HV=%d", current_cpm, hv_pulses);
-
-    transmit_data(tubes[TUBE_TYPE].type, tubes[TUBE_TYPE].nbr, dt, hv_pulses, counts, current_cpm,
-                  have_thp, temperature, humidity, pressure, wifi_status);
+      switch (st) {
+        case MEASUREMENT:
+          log(DEBUG, "Measured GM: cpm= %d HV=%d", current_cpm, hv_pulses);
+          transmit_data(tubes[TUBE_TYPE].type, tubes[TUBE_TYPE].nbr, dt, hv_pulses, counts, current_cpm,
+                        have_thp, temperature, humidity, pressure, wifi_status);
+          break;
+        case ONE_MINUTE:
+          if (Serial_Print_Mode == Serial_One_Minute_Log)
+            log_data_one_minute((current_ms / 1000), current_cpm, counts);
+          break;
+        default:
+          break;
+      }
+      saved_state[st].timestamp = current_ms;
+      saved_state[st].counts = current_counts;
+      saved_state[st].last_count_timestamp = gm_count_timestamp;
+      saved_state[st].hv_pulses = current_hv_pulses;
+    }
   }
 }
 
@@ -268,32 +273,31 @@ void loop() {
   // time between last 2 geiger mueller events [us]
   unsigned int gm_count_time_between;
 
-  read_GMC(&gm_counts, &gm_count_timestamp, &gm_count_time_between);
-
-  read_THP(current_ms, &have_thp, &temperature, &humidity, &pressure);
+  update_ble_status();
+  int wifi_status = update_wifi_status();
+  setup_ntp(wifi_status);
 
   read_hv(&hv_error, &hv_pulses);
   set_status(STATUS_HV, hv_error ? ST_HV_ERROR : ST_HV_OK);
 
-  int wifi_status = update_wifi_status();
-  setup_ntp(wifi_status);
+  read_GMC(&gm_counts, &gm_count_timestamp, &gm_count_time_between);
+  read_THP(current_ms, &have_thp, &temperature, &humidity, &pressure);
 
-  update_ble_status();
+  process_GMC(current_ms, gm_counts, gm_count_timestamp, hv_pulses, have_thp, temperature, humidity, pressure, wifi_status);
 
-  // do any other periodic updates for uplinks
+  // Debug log for last interval between counts, 1x per LOOP_DURATION
+  if (Serial_Print_Mode == Serial_Statistics_Log) {
+    static unsigned long last_counts = 0;
+    if (gm_counts != last_counts) {
+      log_data_statistics(gm_count_time_between);
+      last_counts = gm_counts;
+    }
+  }
+
+  // do any other periodic updates for LoRaWAN(tm) uplinks
   poll_transmission();
 
-  publish(current_ms, gm_counts, gm_count_timestamp, hv_pulses, temperature, humidity, pressure);
-
-  if (Serial_Print_Mode == Serial_One_Minute_Log)
-    one_minute_log(current_ms, gm_counts);
-
-  if (Serial_Print_Mode == Serial_Statistics_Log)
-    statistics_log(gm_counts, gm_count_time_between);
-
-  transmit(current_ms, gm_counts, gm_count_timestamp, hv_pulses, have_thp, temperature, humidity, pressure, wifi_status);
-
-  long loop_duration;
-  loop_duration = millis() - current_ms;
-  iotWebConf.delay((loop_duration < LOOP_DURATION) ? (LOOP_DURATION - loop_duration) : 0);
+  long current_loop_duration;
+  current_loop_duration = millis() - current_ms;
+  iotWebConf.delay((current_loop_duration < LOOP_DURATION) ? (LOOP_DURATION - current_loop_duration) : 0);
 }


### PR DESCRIPTION
Refactor different functions for GMC processing into single one.
- DISPLAYREFRESH --> HEARTBEAT as base processing interval (default 10s)
- Other events snap to this heartbeat interval
- Improved handling of future additions (e.g. Telegram signaling) as separate event in single location
- Removed MINCOUNT as trigger for heartbeat.